### PR TITLE
PADV-521 - Add initial brand definitions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "brand-pearson.com",
+  "version": "0.0.1",
+  "description": "Pearson brand package for MFEs containing Pearson brand definitions (colours and styles).",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Pearson-Advance/brand-pearson.com.git"
+  },
+  "author": "Squirrel18 - <daniel.quiroga@edunext.co>",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Pearson-Advance/brand-pearson.com/issues"
+  },
+  "homepage": "https://github.com/Pearson-Advance/brand-pearson.com#readme"
+}

--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -1,0 +1,1 @@
+// Style overrides for MFEs.

--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -1,0 +1,3 @@
+// General variable definitions.
+
+$brand: #003057 !default;

--- a/paragon/fonts.scss
+++ b/paragon/fonts.scss
@@ -1,0 +1,1 @@
+// Custom fonts definitions.


### PR DESCRIPTION
## Description:

This PR adds initial Pearson brand definitions.

## Test:

- Clone an MFE.
- Install it as follows: `npm install @edx/brand@file:../brand-pearson.com/`
- Test the MFE: `npm run start`

## Reviewers:

- [x] @anfbermudezme 
- [ ] @alexjmpb 