### PR TITLE
PADV 526 - Learning MFE

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -1,1 +1,2 @@
 // Style overrides for MFEs.
+@import 'overrides_learning';

--- a/paragon/_overrides_learning.scss
+++ b/paragon/_overrides_learning.scss
@@ -1,0 +1,82 @@
+// Style overrides for learning MFE.
+body #root {
+    // LEARNING HEADER OVERRIDES
+    header.learning-header {
+        background-color: $brand;
+
+        &>div {
+            padding-top: 13px !important;
+            padding-bottom: 13px !important;
+
+            .user-dropdown {
+                svg {
+                    color: white !important;
+                    margin: 0 5px;
+                }
+                .dropdown-menu {
+                    border-radius: 0 !important;
+                    min-width: initial;
+                    padding: 0 !important;
+                    border: 1px $brand solid;
+                    border-bottom: none;
+                }
+
+                a {
+                    color: $brand !important;
+                    border-bottom: #777 1px solid;
+                }
+            }
+        }
+
+        span, a {
+            color: white !important;
+        }
+
+        button.dropdown-toggle {
+            &::after{
+                color: $white;
+            }
+
+            &::before {
+                content: none;
+            }
+
+            &:hover,
+            &:focus,
+            &:focus-visible,
+            &:focus-within,
+            &:active{
+                background-color: $brand;
+                border: none !important;
+                outline: none !important;
+            }
+
+            border: none !important;
+            outline: none;
+        }
+    }
+
+    // LEARNING INSTRUCTOR TOOLBAR
+    div[data-testid="instructor-toolbar"]>div {
+        background-color: $brand-secondary !important;
+
+        &>div {
+            padding-top: 5px !important;
+            padding-bottom: 5px !important;
+        }
+    }
+
+    // LEARNING MAIN CONTENT
+    header.learning-header ~ main { // Selector to specifically select the main content of the learning MFE
+        min-height: 100vh;
+
+        .btn.btn-brand {
+            background-color: $brand;
+        }
+    }
+
+    // LEARNING FOOTER OVERRIDES
+    header.learning-header ~ footer { // Selector to specifically select the footer of the learning MFE
+        background-color: $brand !important;
+    }
+}

--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -1,3 +1,4 @@
 // General variable definitions.
 
 $brand: #003057 !default;
+$brand-secondary: #007FA3 !default;


### PR DESCRIPTION
## Description:

This PR aims to add the styles for the pearson theme for the frontend app learning, and also adds the styles for the header and the footer. 

## Screenshots

![Screenshot from 2023-06-08 19-30-26](https://github.com/Pearson-Advance/brand-pearson.com/assets/62396424/2bda15ab-c4b1-4e76-a846-100f958bca9c)

![Screenshot from 2023-06-08 19-30-33](https://github.com/Pearson-Advance/brand-pearson.com/assets/62396424/d650bf4f-0c55-4792-a914-98ed5334a085)

## How To Test:

- Clone the learning MFE.
- Install it as follows: `npm install @edx/brand@file:../brand-pearson.com/`
- Test the MFE: `npm run start`

## Reviewers:

- [ ] @anfbermudezme 
- [ ] @Squirrel18 
- [ ] @sergivalero20  