### PR TITLE
PADV-525 - Add style overrides for MFEs.

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -1,2 +1,3 @@
 // Style overrides for MFEs.
 @import 'overrides_learning';
+@import 'overrides_common';

--- a/paragon/_overrides_common.scss
+++ b/paragon/_overrides_common.scss
@@ -1,0 +1,66 @@
+// Gradebook MFE overrides.
+
+body #root {
+    header.site-header-desktop,
+    header.site-header-mobile {
+        background-color: $brand;
+
+        .dropdown-menu {
+            border: 1px solid $brand;
+
+            .dropdown-item {
+                color: $brand;
+            }
+        }
+
+        span, a {
+            color: $white;
+        }
+
+        .menu-content {
+            a {
+                color: $brand;
+            }
+        }
+
+        button.menu-trigger {
+            color: $white;
+
+            &::after{
+                color: $brand;
+            }
+
+            &::before {
+                content: none;
+            }
+
+            &:hover,
+            &:focus,
+            &:focus-visible,
+            &:focus-within,
+            &:active {
+                color: $brand;
+                background-color: $white;
+                border: $brand;
+                outline: $brand;
+
+                span, a {
+                    color: $brand;
+                }
+            }
+
+            border: 1px solid $white;
+            outline: $white;
+        }
+    }
+
+    header.site-header-desktop ~ main,
+    header.site-header-mobile ~ main { // Selector to specifically select the the standard MFE header
+        min-height: 100vh;
+    }
+
+    header.site-header-desktop ~ footer,
+    header.site-header-mobile ~ footer { // Selector to specifically select the the standard MFE footer
+        background-color: $brand !important;
+    }
+}

--- a/paragon/_overrides_learning.scss
+++ b/paragon/_overrides_learning.scss
@@ -1,4 +1,7 @@
 // Style overrides for learning MFE.
+
+$learning-gray: #777;
+
 body #root {
     // LEARNING HEADER OVERRIDES
     header.learning-header {
@@ -10,7 +13,7 @@ body #root {
 
             .user-dropdown {
                 svg {
-                    color: white !important;
+                    color: $white !important;
                     margin: 0 5px;
                 }
                 .dropdown-menu {
@@ -23,13 +26,13 @@ body #root {
 
                 a {
                     color: $brand !important;
-                    border-bottom: #777 1px solid;
+                    border-bottom: $learning-gray 1px solid;
                 }
             }
         }
 
         span, a {
-            color: white !important;
+            color: $white !important;
         }
 
         button.dropdown-toggle {


### PR DESCRIPTION
## Description:

This PR adds the necessary style overrides for the Gradebook, Profile and Account MFEs.

## Screenshot:

Gradebook:
![image](https://github.com/Pearson-Advance/brand-pearson.com/assets/17520199/aa210794-d03f-4991-af6d-01a0d0924cbf)

Account
![image](https://github.com/Pearson-Advance/brand-pearson.com/assets/73655023/6ab09aba-9c33-4d3f-8d40-1a5c67d04ab5)

Profile:
![Screenshot from 2023-06-09 17-41-44](https://github.com/Pearson-Advance/brand-pearson.com/assets/62396424/3cb2c644-7009-4887-a47e-d46a1abd6780)


## Notes:

- We cannot apply more explicit rules, as HTML components have vague references.
- There is a bug with the footer logo that prevents us from overwriting it.

## Reviewers:

- [ ] @alexjmpb 
- [ ] @anfbermudezme 