### PR TITLE
feat: add styles to the Pearson footer MFE.

### DIFF
--- a/paragon/_overrides_common.scss
+++ b/paragon/_overrides_common.scss
@@ -73,9 +73,36 @@ body #root {
     header.site-header-desktop ~ footer,
     header.site-header-mobile ~ footer { // Selector to specifically select the the standard MFE footer
         background-color: $brand !important;
+        flex-direction: column;
 
-        img {
-            max-height: 35px !important;
+        .container-fluid {
+            align-items: center;
+            justify-content: center;
+
+            ul {
+                list-style: none;
+                display: inline-flex;
+                padding: 0;
+                margin-bottom: 3rem;
+
+                li:last-child::before {
+                    content: "|";
+                    padding: 0 20px;
+                    color: $white;
+                }
+
+                a {
+                    font-size: 0.875rem;
+                    color: $white !important;
+                }
+            }
+
+            &.copyright {
+                p {
+                    font-size: 0.7rem;
+                    color: $white !important;
+                }
+            }
         }
     }
 }

--- a/paragon/_overrides_learning.scss
+++ b/paragon/_overrides_learning.scss
@@ -116,9 +116,36 @@ body #root {
     // LEARNING FOOTER OVERRIDES
     header.learning-header ~ footer { // Selector to specifically select the footer of the learning MFE
         background-color: $brand !important;
+        flex-direction: column;
 
-        img {
-            max-height: 35px !important;
+        .container-fluid {
+            align-items: center;
+            justify-content: center;
+
+            ul {
+                list-style: none;
+                display: inline-flex;
+                padding: 0;
+                margin-bottom: 3rem;
+
+                li:last-child::before {
+                    content: "|";
+                    padding: 0 20px;
+                    color: $white;
+                }
+
+                a {
+                    font-size: 0.875rem;
+                    color: $white !important;
+                }
+            }
+
+            &.copyright {
+                p {
+                    font-size: 0.7rem;
+                    color: $white !important;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Description:

This PR adds some style to adjust the https://github.com/Pearson-Advance/frontend-component-footer

## Screenshots:
![image](https://github.com/Pearson-Advance/brand-pearson.com/assets/17520199/d7d64d1d-29c0-46b3-a3a6-e700ab4c5835)
![image](https://github.com/Pearson-Advance/brand-pearson.com/assets/17520199/8ed0fc42-b1c1-4207-8dad-8616e3705061)
![image](https://github.com/Pearson-Advance/brand-pearson.com/assets/17520199/ce1fa881-a8a0-404b-9f82-4f382474c7ba)
![image](https://github.com/Pearson-Advance/brand-pearson.com/assets/17520199/0f0bffaf-7016-44e0-a23a-358efa102f78)
![image](https://github.com/Pearson-Advance/brand-pearson.com/assets/17520199/02bec742-537d-47a8-a442-69ade646f552)

## How to test:

- Clone an MFE.
- Install it as follows: npm install @edx/brand@file:../brand-pearson.com/
- Test the MFE: npm run start
- Configure MFE runtime feature: https://github.com/openedx/edx-platform/pull/30830
- Adds these settings to MFE_CONFIG: FOOTER_PRIVACY_POLICY_LINK FOOTER_TERMS_OF_SERVICE_LINK

## Reviewers:

- [ ] @anfbermudezme 
- [ ] @alexjmpb 